### PR TITLE
Fix dependency of unit test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,2 +1,3 @@
 include_directories(${catkin_INCLUDE_DIRS})
 catkin_add_gtest(vision_msgs_test main.cpp)
+add_dependencies(vision_msgs_test ${${PROJECT_NAME}_EXPORTED_TARGETS})


### PR DESCRIPTION
This PR fixes the unit test, making it able to run tests with `catkin_make run_tests` directly, without running `catkin_make` first. [1]

[1] http://wiki.ros.org/catkin/CMakeLists.txt#Important_Prerequisites.2BAC8-Constraints